### PR TITLE
Add B-RecurringTasks extension

### DIFF
--- a/src/main/java/elena/apps/Main.java
+++ b/src/main/java/elena/apps/Main.java
@@ -14,7 +14,7 @@ import javafx.stage.Stage;
  * A GUI for Elena using FXML.
  */
 public class Main extends Application {
-    private final Elena elena = new Elena();
+    private final Elena elena = new Elena("./data/elena.txt");
 
     @Override
     public void start(Stage stage) {

--- a/src/main/java/elena/core/Elena.java
+++ b/src/main/java/elena/core/Elena.java
@@ -248,4 +248,31 @@ public class Elena {
         assert input != null : "Input to getResponse must not be null";
         return "Elena heard: " + input;
     }
+
+    /**
+     * Handles user input from GUI and returns a response string.
+     */
+    public String handleInput(String input) {
+        if (input == null || input.isEmpty()) return "";
+        try {
+            if (handleCommand(input)) {
+                return "Bye. Hope to see you again soon!";
+            }
+        } catch (ElenaException e) {
+            return "OOPS!!! " + e.getMessage();
+        } catch (Exception e) {
+            return "Unexpected error: " + e.getMessage();
+        }
+
+        // For 'list' command, we want the task list as a string
+        if (input.toLowerCase().startsWith("list")) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < tasks.size(); i++) {
+                sb.append(i + 1).append(". ").append(tasks.get(i)).append("\n");
+            }
+            return sb.toString();
+        }
+
+        return "Task updated.";
+    }
 }

--- a/src/main/java/elena/core/Parser.java
+++ b/src/main/java/elena/core/Parser.java
@@ -4,6 +4,7 @@ import elena.tasks.Task;
 import elena.tasks.Todo;
 import elena.tasks.Deadline;
 import elena.tasks.Event;
+import elena.tasks.Recurring;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -41,9 +42,21 @@ public class Parser {
                 return parseDeadline(rest);
             case "event":
                 return parseEvent(rest);
+            case "recurring":
+                return parseRecurring(rest);
             default:
                 throw ElenaException.invalidCommand(input);
         }
+    }
+
+    private static Recurring parseRecurring(String rest) throws ElenaException {
+        String[] parts = rest.split("/recur", 2);
+        if (parts.length < 2 || parts[0].trim().isEmpty() || parts[1].trim().isEmpty()) {
+            throw new ElenaException("Usage: recurring <description> /recur <daily|weekly|monthly>");
+        }
+        String description = parts[0].trim();
+        String recurrence = parts[1].trim().toLowerCase();
+        return new Recurring(description, recurrence);
     }
 
     private static Todo parseTodo(String rest) throws ElenaException {

--- a/src/main/java/elena/core/Storage.java
+++ b/src/main/java/elena/core/Storage.java
@@ -1,9 +1,10 @@
 package elena.core;
 
 import elena.tasks.Task;
+import elena.tasks.Todo;
 import elena.tasks.Deadline;
 import elena.tasks.Event;
-import elena.tasks.Todo;
+import elena.tasks.Recurring;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -83,6 +84,9 @@ public class Storage {
             case "E":
                 task = decodeEvent(parts);
                 break;
+            case "R":
+                task = decodeRecurring(parts);
+                break;
             default:
                 throw new IllegalArgumentException("Invalid task type: " + type);
         }
@@ -92,6 +96,10 @@ public class Storage {
         }
 
         return task;
+    }
+
+    private Task decodeRecurring(String[] parts) {
+        return new Recurring(parts[2], parts[3]);
     }
 
     private Task decodeDeadline(String[] parts) {

--- a/src/main/java/elena/tasks/Recurring.java
+++ b/src/main/java/elena/tasks/Recurring.java
@@ -1,0 +1,24 @@
+package elena.tasks;
+
+public class Recurring extends Task {
+    private final String recurrence; // e.g., "weekly", "daily"
+
+    public Recurring(String description, String recurrence) {
+        super(description, TaskType.RECURRING); // Add RECURRING to TaskType
+        this.recurrence = recurrence;
+    }
+
+    public String getRecurrence() {
+        return recurrence;
+    }
+
+    @Override
+    public String toSaveFormat() {
+        return type.getCode() + " | " + (isDone ? "1" : "0") + " | " + description + " | " + recurrence;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " (recurs: " + recurrence + ")";
+    }
+}

--- a/src/main/java/elena/tasks/TaskType.java
+++ b/src/main/java/elena/tasks/TaskType.java
@@ -6,7 +6,8 @@ package elena.tasks;
 public enum TaskType {
     TODO("T"),
     DEADLINE("D"),
-    EVENT("E");
+    EVENT("E"),
+    RECURRING("R");
 
     private final String code;
 

--- a/src/main/java/elena/ui/MainWindow.java
+++ b/src/main/java/elena/ui/MainWindow.java
@@ -46,7 +46,7 @@ public class MainWindow extends AnchorPane {
     @FXML
     private void handleUserInput() {
         String input = userInput.getText();
-        String response = elena.getResponse(input);
+        String response = elena.handleInput(input);
         dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, userImage),
                 DialogBox.getDukeDialog(response, elenaImage)


### PR DESCRIPTION
- Introduced a new Recurring task type to support recurring tasks such as weekly project meetings or daily standups.
- Added Recurring.java extending Task with a recurrence field and appropriate toString() and toSaveFormat() methods.
- Updated TaskType enum to include RECURRING with code "R".
- Updated Parser.java to support parsing recurring tasks.
- Tested adding, listing, and saving recurring tasks to ensure compatibility with existing task management features.

Tag the commit as BCD-Extension as per assignment requirements.